### PR TITLE
Feature/file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _testmain.go
 tags
 
 cover.out
+.idea

--- a/pcd.go
+++ b/pcd.go
@@ -239,6 +239,8 @@ func (e *Episode) Download(path string, writer io.Writer) error {
 		return ErrCouldNotDownload
 	}
 
+	log.Printf("Sucessfully Downloaded to: %s", fpath)
+
 	return nil
 }
 
@@ -256,7 +258,7 @@ func (e *Episode) FileName(u *url.URL) string {
 	finalFileName.WriteString(base64.RawURLEncoding.EncodeToString(guidHash))
 	finalFileName.WriteString("__")
 
-	finalFileName.WriteString(urlpath.Base(u.Path))
+	finalFileName.WriteString(strings.ReplaceAll(urlpath.Base(u.Path), " ", "_"))
 
 	return finalFileName.String()
 }

--- a/pcd_test.go
+++ b/pcd_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -232,6 +233,8 @@ func TestDownload(t *testing.T) {
 	episode := episodes[0]
 	ts := testServer()
 	episode.URL = ts.URL + "/sample.mp3"
+	episode.Title = "some_title"
+	episode.Guid = "some_guid"
 
 	if err := episode.Download(randomPath(t), nil); err != nil {
 		t.Errorf("Expected to be able to download episode, but got: %#v", err)
@@ -299,6 +302,7 @@ func TestParseEpisodes(t *testing.T) {
 func TestGobEncodeAndDecode(t *testing.T) {
 	episode := Episode{
 		Title: "test",
+		Guid:  "guid",
 	}
 
 	content, err := toGOB64([]Episode{episode})
@@ -323,5 +327,23 @@ func TestGobEncodeAndDecode(t *testing.T) {
 	}
 	if episodes[0].Title != episode.Title {
 		t.Errorf("Expected title to be %s, but got %s", episode.Title, episodes[0].Title)
+	}
+}
+
+func TestRepeatableFileName(t *testing.T) {
+	episode := Episode{
+		Title: "This is a cool episode",
+		URL:   "https://some_fake_website.com/episodes/cool.mp3",
+		Guid:  "https://some_fake_website.com/blog/cool",
+	}
+
+	urlData, err := url.Parse(episode.URL)
+
+	if err != nil {
+		t.Errorf("Didn't expect an error, but got: %#v", err)
+	}
+
+	if episode.FileName(urlData) != episode.FileName(urlData) {
+		t.Errorf("file names should be repeatable")
 	}
 }

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -52,6 +52,7 @@ type Item struct {
 	Enclosure  Enclosure
 	Downloaded bool
 	Date       PodcastDate
+	Guid       Guid
 }
 
 type ItemTitle struct {
@@ -73,6 +74,11 @@ type Enclosure struct {
 type PodcastDate struct {
 	XMLName xml.Name `xml:"pubDate"`
 	Date    string   `xml:",chardata"`
+}
+
+type Guid struct {
+	XMLName xml.Name `xml:"guid"`
+	Guid    string   `xml:",chardata"`
 }
 
 var (

--- a/rss/parser_test.go
+++ b/rss/parser_test.go
@@ -213,6 +213,7 @@ func TestParse(t *testing.T) {
 		{"podcast title", feed.Channel.Title.Title, "Title of Podcast"},
 		{"podcast description", feed.Channel.Description.Description, "Description of podcast."},
 		{"title of item", feed.Channel.Items[0].Title.Title, "Title of Podcast Episode"},
+		{"guid of item", feed.Channel.Items[0].Guid.Guid, "http://example.com/podcast-1"},
 	}
 
 	for _, e := range table {
@@ -266,6 +267,7 @@ func TestParseRFC1123Z(t *testing.T) {
 		{"podcast description", feed.Channel.Description.Description, "Description of podcast."},
 		{"title of item", feed.Channel.Items[0].Title.Title, "Title of Podcast Episode"},
 		{"publication date", feed.Channel.Items[0].Date.Date, "Thu, 21 Dec 2016 16:01:07 GMT"},
+		{"guid of item", feed.Channel.Items[0].Guid.Guid, "http://example.com/podcast-1"},
 	}
 
 	for _, e := range table {


### PR DESCRIPTION
Many podcasts name their podcast episodes files the same. For example https://feeds.acast.com/public/shows/c939f8d1-c4bc-478e-8bb9-e5343f9a7ab5. This means if you want to download multiple episodes from one podcast the user would have to move the previous file or delete it. A solution to this is to create a filename based on the title, episode guid and filename. This would reduce the chance of filename clashes.

I'm also printing the filename to stdout for reference once the file has been downloaded successfully