### PR TITLE
feat: Introduced field in config to change episode filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ I wanted to be able to download my favorite podcasts in a simple way, and on the
 - You will need to create a configuration file under ~/.config/pcd.yml that has the following options: 
 ```
 ---
+download_filename: "{title}__cool-podcast" # optional, supports variables {title}, {date}. {filename} all of which are derived from episode data 
 podcasts:
   - id: 1
     name: biggest_problem

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -128,7 +128,8 @@ func downloadEpisode(podcast *pcd.Podcast, episodeN int) {
 	bar.ShowSpeed = true
 	bar.Start()
 
-	if err := episodeToDownload.Download(podcast.Path, bar); err != nil {
+	downloadFilename := getDownloadFilename()
+	if err := episodeToDownload.Download(podcast.Path, downloadFilename, bar); err != nil {
 		log.Fatalf("Could not download episode: %#v", err)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-        "strings"
+	"strings"
 
 	"github.com/kvannotten/pcd"
 	homedir "github.com/mitchellh/go-homedir"
@@ -111,10 +111,20 @@ func findAll() []pcd.Podcast {
 	return podcasts
 }
 
+func getDownloadFilename() string {
+	var downloadFilename string
+
+	if err := viper.UnmarshalKey("download_filename", &downloadFilename); err != nil {
+		log.Fatalf("Could not parse 'podcasts' entry in config: %v", err)
+	}
+
+	return downloadFilename
+}
+
 func findByNameFragment(name string) *pcd.Podcast {
 	return findByFunc(func(podcast *pcd.Podcast) bool {
 		return strings.Contains(
-                    strings.ToLower(podcast.Name), strings.ToLower(name))
+			strings.ToLower(podcast.Name), strings.ToLower(name))
 	})
 }
 
@@ -126,19 +136,19 @@ func findByID(id int) *pcd.Podcast {
 
 func findByFunc(fn func(podcast *pcd.Podcast) bool) *pcd.Podcast {
 	podcasts := findAll()
-        var matchedPodcasts = make([]*pcd.Podcast, 0)
+	var matchedPodcasts = make([]*pcd.Podcast, 0)
 
 	for _, podcast := range podcasts {
 		if fn(&podcast) {
-                    matchedPodcast := podcast
-                    matchedPodcasts = append(matchedPodcasts, &matchedPodcast)
+			matchedPodcast := podcast
+			matchedPodcasts = append(matchedPodcasts, &matchedPodcast)
 		}
 	}
-        if len(matchedPodcasts) == 1 {
+	if len(matchedPodcasts) == 1 {
 		return matchedPodcasts[0]
-        } else {
-                log.Fatalf("Provided search term matched too many podcasts: %v", matchedPodcasts)
-        }
+	} else {
+		log.Fatalf("Provided search term matched too many podcasts: %v", matchedPodcasts)
+	}
 
 	return nil
 }

--- a/pcd.go
+++ b/pcd.go
@@ -27,11 +27,14 @@ import (
 	"os"
 	urlpath "path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/kvannotten/pcd/rss"
 	"github.com/pkg/errors"
 )
+
+var nonNumAndLetterRegex = regexp.MustCompile(`[^a-zA-Z0-9:_\-@ ]+`)
 
 type Podcast struct {
 	ID   int
@@ -181,7 +184,7 @@ func (p *Podcast) String() string {
 
 // Download downloads an episode in 'path'. The writer argument is optional
 // and will just mirror everything written into it (useful for tracking the speed)
-func (e *Episode) Download(path string, writer io.Writer) error {
+func (e *Episode) Download(path, downloadFilename string, writer io.Writer) error {
 	u, err := url.Parse(e.URL)
 	if err != nil {
 		log.Printf("Parse episode url failed: %#v", err)
@@ -199,6 +202,13 @@ func (e *Episode) Download(path string, writer io.Writer) error {
 	}
 
 	filename := urlpath.Base(u.Path)
+
+	if downloadFilename != "" {
+		parsedDownloadFilename := e.ParseDownloadFilename(downloadFilename, filename)
+		filename = parsedDownloadFilename
+		fmt.Println("this is the filename", filename)
+	}
+
 	fpath := filepath.Join(path, filename)
 
 	if _, err := os.Stat(fpath); !os.IsNotExist(err) {
@@ -236,6 +246,23 @@ func (e *Episode) Download(path string, writer io.Writer) error {
 	}
 
 	return nil
+}
+
+func (e *Episode) ParseDownloadFilename(downloadFilename, filename string) string {
+	ext := filepath.Ext(filename)
+
+	filename = strings.Replace(filename, ext, "", 1)
+	variableEvaluator := map[string]string{
+		"{title}":    e.Title,
+		"{date}":     e.Date,
+		"{filename}": filename,
+	}
+
+	for varName, value := range variableEvaluator {
+		downloadFilename = strings.ReplaceAll(downloadFilename, varName, value)
+	}
+
+	return nonNumAndLetterRegex.ReplaceAllString(downloadFilename, "") + ext
 }
 
 func parseEpisodes(content io.Reader) ([]Episode, error) {


### PR DESCRIPTION
Unfortunately some podcasters name the the episode filenames the same. This has made be write a PR that allows for the user to use their own format of how the filename should be composed. I have introduced an additional parameter called `download_filename`. This field is optional but if it exists will help override the current episode filename.

You should declare the field at the top level of the config like so
```yaml
download_filename: "{title}_downloaded_from_pcd"
```

The idea is copied from the greg podcast cli client. Three 'variables' are supported which are shown below
* `{title}`
* `{date}`
* `{filename}`

The file extension used is that of the orignal filename.

I've also ran go fmt on the existing codebase