### PR TITLE
feat(download): introduced download latest command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ podcasts:
 - You have to "sync" the feeds: `pcd sync`
 - (Optionally) List the episodes of a podcast: `pcd ls 1` or `pcd ls biggest_problem`
 - Download the first episode of `biggest_problem`: `pcd d 1 1` or `pcd d biggest_problem 1`
+- Download the latest episode from each podcast `pcd dl`
 
 ## Support
 

--- a/cmd/download_latest.go
+++ b/cmd/download_latest.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+var downloadLatestCmd = &cobra.Command{
+	Use:     "download-latest",
+	Aliases: []string{"dl"},
+	Short:   "Downloads the latest episode from each podcast feed",
+	Long: `
+This command will download the latest episode from each podcast
+
+For example
+
+pcd da
+`,
+	Run: downloadLatest,
+}
+
+func init() {
+	rootCmd.AddCommand(downloadLatestCmd)
+}
+
+func downloadLatest(cmd *cobra.Command, args []string) {
+	podcasts := findAll()
+
+	for _, singlePodcast := range podcasts {
+
+		if err := singlePodcast.Load(); err != nil {
+			log.Println("Could not load podcast: ", err)
+			continue
+		}
+
+		if err := downloadEpisode(&singlePodcast, len(singlePodcast.Episodes)); err != nil {
+			log.Println(err)
+		}
+	}
+}


### PR DESCRIPTION
Introduces a `download latest` command. Not to be confused with the existing download command that can download the latest episode.

This command downloads the latest episode from **each podcast** in the config