### PR TITLE
Post download command which runs once an episode has been downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ I wanted to be able to download my favorite podcasts in a simple way, and on the
 - You will need to create a configuration file under ~/.config/pcd.yml that has the following options: 
 ```
 ---
-download_filename: "{title}__cool-podcast" # optional, supports variables {title}, {date}. {filename} all of which are derived from episode data 
+# optional, supports variables {title}, {date}. {filename} all of which are derived from episode data 
+download_filename: "{title}__cool-podcast" 
+# optional, command runs once an episode has been downloaded,
+# I use this to encode downloaded episodes in theory you can use this functionality for other purposes. 
+post_download_command: 'ffmpeg -y -i {input_file} -b:a 192k -ac 1 -ar 44100 {output_file}' 
 podcasts:
   - id: 1
     name: biggest_problem
@@ -32,11 +36,3 @@ podcasts:
 - (Optionally) List the episodes of a podcast: `pcd ls 1` or `pcd ls biggest_problem`
 - Download the first episode of `biggest_problem`: `pcd d 1 1` or `pcd d biggest_problem 1`
 - Download the latest episode from each podcast `pcd dl`
-
-## Support
-
-Community support can be had via the matrix channel: https://matrix.to/#/#pcd:kristof.tech
-
-## Contributions
-
-Contributions are welcome, as long as they are in line with the philosophy of keeping it simple and to the point. No features that are out of the scope of this application will be accepted.

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -130,10 +130,10 @@ func downloadEpisode(podcast *pcd.Podcast, episodeN int) error {
 	bar := pb.New(size).SetUnits(pb.U_BYTES)
 	bar.ShowTimeLeft = true
 	bar.ShowSpeed = true
-	bar.Start()
 
 	downloadFilename := getDownloadFilename()
-	if err := episodeToDownload.Download(podcast.Path, downloadFilename, bar); err != nil {
+	postDownloadCommand := getPostDownloadCommand()
+	if err := episodeToDownload.Download(podcast.Path, downloadFilename, postDownloadCommand, bar); err != nil {
 		bar.Finish()
 		return fmt.Errorf("Could not download episode: %#v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,10 +115,20 @@ func getDownloadFilename() string {
 	var downloadFilename string
 
 	if err := viper.UnmarshalKey("download_filename", &downloadFilename); err != nil {
-		log.Fatalf("Could not parse 'podcasts' entry in config: %v", err)
+		log.Fatalf("Could not parse 'download_filename' entry in config: %v", err)
 	}
 
 	return downloadFilename
+}
+
+func getPostDownloadCommand() string {
+	var postDownloadCommand string
+
+	if err := viper.UnmarshalKey("post_download_command", &postDownloadCommand); err != nil {
+		log.Fatalf("Could not parse 'post_download_command' entry in config: %v", err)
+	}
+
+	return postDownloadCommand
 }
 
 func findByNameFragment(name string) *pcd.Podcast {


### PR DESCRIPTION
I wanted to encode the the episodes of podcasts once they're downloaded. This MR achieves that, the config option is shown below. 

* `{input_file}` will be a file which is stored in the OS's temp directory. It gets deleted once the post download command has finished. It's a copy of the downloaded media
* `{output_file}` is referrring to the actual permanent  location of the downloaded media.

NOTE: if the post download command fails the original downloaded media is deleted you the user will have the run the pcd download command again in order to save the episode.


```yaml
post_download_command: 'ffmpeg -y -i {input_file} -b:a 192k -ac 1 -ar 44100 {output_file}'
``` 