### PR TITLE
feat new hash and guid variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ I wanted to be able to download my favorite podcasts in a simple way, and on the
 - You will need to create a configuration file under ~/.config/pcd.yml that has the following options: 
 ```
 ---
-# optional, supports variables {title}, {date}. {filename} all of which are derived from episode data 
+# optional, supports variables {title}, {date}. {filename}, {guid}, {hash} all of which are derived from episode data 
 download_filename: "{title}__cool-podcast" 
 # optional, command runs once an episode has been downloaded,
 # I use this to encode downloaded episodes in theory you can use this functionality for other purposes. 

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -52,6 +52,12 @@ type Item struct {
 	Enclosure  Enclosure
 	Downloaded bool
 	Date       PodcastDate
+	Guid       Guid
+}
+
+type Guid struct {
+	XMLName xml.Name `xml:"guid"`
+	Guid    string   `xml:",chardata"`
 }
 
 type ItemTitle struct {


### PR DESCRIPTION
Introduce `{hash}` and `{guid}` variable names for episode filenames